### PR TITLE
Update Home navigation link to "Home & Garden"

### DIFF
--- a/components/Header.js
+++ b/components/Header.js
@@ -25,7 +25,7 @@ const Header = () => {
               Electronics
             </Link>
             <Link href="/category/home" className="text-gray-700 hover:text-gray-900 transition-colors">
-              Home
+              Home & Garden
             </Link>
           </nav>
 


### PR DESCRIPTION
## Purpose
The user identified confusion with having two "Home" buttons in the navigation. This change clarifies the purpose of the category link by renaming it to be more descriptive and distinguish it from other home-related navigation elements.

## Code changes
- Updated the navigation link text in `components/Header.js` from "Home" to "Home & Garden" to better describe the category and avoid confusion with duplicate "Home" buttons

tag @builderio-bot for anything you want the bot to do

🔗 [Edit in Builder.io](https://builder.io/app/projects/6aef09985a6e4bb18e332366f62b497c/zen-garden)

👀 [Preview Link](https://6aef09985a6e4bb18e332366f62b497c-zen-garden.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>6aef09985a6e4bb18e332366f62b497c</projectId>-->
<!--<branchName>zen-garden</branchName>-->